### PR TITLE
fix duplicate args when running task multiple times

### DIFF
--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -244,6 +244,7 @@ local function tasks(opts)
         arg_string = arg_string .. " " .. arg
       end
       task["command"] = task["command"] .. arg_string
+      task["args"] = nil
     end
     table.insert(tasks_with_args, task)
   end


### PR DESCRIPTION
Hi @EthanJWright,

When running the same task multiple times, I saw the args were appended repeatedly. Possible fix could be this :)