### PR TITLE
Add option for user specified json parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,40 @@ require("vstask").setup({
     tab = {
       direction = 'tab',
     }
-  }
+  },
+  json_parser = 'vim.fn.json_decode'
 })
 EOF
 ```
+
+### Work with json5 files
+
+VS Code uses json5 which allows use of comments and trailing commas.
+If you want to use the same tasks as your teammates, and they leave trailing commas and comments in the project's task.json,
+you will need another parser than the default `vim.fn.json_decode`.
+
+A proposed solution: 
+Add the following to your dependencies.
+
+```lua
+lua <<EOF
+    {
+      'Joakker/lua-json5',
+      run = './install.sh'
+    }
+EOF
+```
+
+And add the following option in the setup: 
+
+```lua
+lua <<EOF
+require("vstask").setup({
+    json_parser = require('json5').parse
+})
+EOF
+```
+
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Info on Fork
+
+This fork was created to be able to parse json5. It is a quick and dirty solution that works for me. I'll clean it up and make it easy to use when others show interest. 
+
+
+Below is the original README.md:
+
+---------------
+
 # VS Tasks
 
 Telescope plugin to load and run tasks in a project that conform to VS Code's [Editor Tasks](https://code.visualstudio.com/docs/editor/tasks)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-# Info on Fork
-
-This fork was created to be able to parse json5. It is a quick and dirty solution that works for me. I'll clean it up and make it easy to use when others show interest. 
-
-
-Below is the original README.md:
-
----------------
-
 # VS Tasks
 
 Telescope plugin to load and run tasks in a project that conform to VS Code's [Editor Tasks](https://code.visualstudio.com/docs/editor/tasks)

--- a/lua/vstask/Config.lua
+++ b/lua/vstask/Config.lua
@@ -3,7 +3,7 @@
 ---@param data string Data to decode
 ---@returns table json_obj Decoded JSON object
 local json_decode = function(data)
-  local ok, result = pcall(vim.fn.json_decode, vim.fn.readfile(data))
+  local ok, result = pcall(require('json5').parse, vim.fn.readfile(data))
   if ok then
     return result
   else

--- a/lua/vstask/Config.lua
+++ b/lua/vstask/Config.lua
@@ -1,11 +1,13 @@
 --- Decodes from JSON.
 ---
 ---@param data string Data to decode
+---@param parser function Parser to use
 ---@returns table json_obj Decoded JSON object
-local json_decode = function(data)
+local json_decode = function(data, parser)
+  local Parser = parser or vim.fn.json_decode
   local lines = vim.fn.readfile(data)
   local inputstr = table.concat(lines, '\n')
-  local ok, result = pcall(require('json5').parse, inputstr)
+  local ok, result = pcall(Parser, inputstr)
   if ok then
     return result
   else
@@ -15,8 +17,9 @@ end
 
 --- load settings from JSON file
 ---@param path string JSON file path
+---@param parser function the parser to use
 ---@return boolean is_error if error then true
-local load_setting_json = function(path)
+local load_setting_json = function(path, parser)
   vim.validate {
     path = { path, 's' },
   }
@@ -26,7 +29,7 @@ local load_setting_json = function(path)
     return
   end
 
-  local decoded, err = json_decode(path)
+  local decoded, err = json_decode(path, parser)
   if err ~= nil then
     print(err)
     return

--- a/lua/vstask/Config.lua
+++ b/lua/vstask/Config.lua
@@ -3,7 +3,9 @@
 ---@param data string Data to decode
 ---@returns table json_obj Decoded JSON object
 local json_decode = function(data)
-  local ok, result = pcall(require('json5').parse, vim.fn.readfile(data))
+  local lines = vim.fn.readfile(data)
+  local inputstr = table.concat(lines, '\n')
+  local ok, result = pcall(require('json5').parse, inputstr)
   if ok then
     return result
   else

--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -36,6 +36,13 @@ local set_cache_strategy = function(strategy)
   CACHE_STRATEGY = strategy
 end
 
+local JSON_PARSER
+--- Set JSON Parser
+---@param json_parser function that takes inputstr
+local set_json_parser = function(json_parser)
+  JSON_PARSER = json_parser
+end
+
 local function file_exists(name)
   local f = io.open(name, "r")
   if f ~= nil then
@@ -59,7 +66,7 @@ local function get_inputs()
     vim.notify(MISSING_FILE_MESSAGE, "error")
     return {}
   end
-  local config = Config.load_json(path)
+  local config = Config.load_json(path, JSON_PARSER)
   if (not setContains(config, "inputs")) then
     Inputs = {}
     return Inputs
@@ -153,7 +160,7 @@ local function auto_detect_npm()
     return script_tasks
   end
 
-  local config = Config.load_json(packagejson)
+  local config = Config.load_json(packagejson, JSON_PARSER)
   if (setContains(config, "scripts")) then
     local scripts = config["scripts"]
     for key in pairs(scripts) do
@@ -178,7 +185,7 @@ local function get_tasks()
 
 
   get_inputs()
-  local tasks = Config.load_json(path)
+  local tasks = Config.load_json(path, JSON_PARSER)
   local task_list = tasks["tasks"]
   -- add script_tasks to Tasks
   local script_tasks = auto_detect_npm()
@@ -315,7 +322,7 @@ local function get_launches()
     return {}
   end
   get_inputs()
-  local configurations = Config.load_json(path)
+  local configurations = Config.load_json(path, JSON_PARSER)
   Launches = configurations["configurations"]
   launch_cache = create_cache(Launches, "name")
   return Launches
@@ -333,5 +340,6 @@ return {
   Cache_strategy = set_cache_strategy,
   Set_autodetect = set_autodetect,
   Set_cache_json_conf = set_cache_json_conf,
-  Set_config_dir = set_config_dir
+  Set_config_dir = set_config_dir,
+  Set_json_parser = set_json_parser
 }

--- a/lua/vstask/init.lua
+++ b/lua/vstask/init.lua
@@ -33,6 +33,9 @@ function M.setup(opts)
   if opts.cache_json_conf ~= nil then
     M.Parse.Set_cache_json_conf(opts.cache_json_conf)
   end
+  if opts.json_parser ~= nil then
+    M.Parse.Set_json_parser(opts.json_parser)
+  end
 end
 
 M.get_last = M.Telescope.Get_last


### PR DESCRIPTION
See issue #21 for details.

This pull request will not break current configs. The only change will be to create a string from the list from `readfile()`.
`vim.fn.json_decode()` works well with return form `readfile()` and with strings. So this will be unnoticed by current users.
It is necessary for other parsers like [Joakker's](https://github.com/Joakker/lua-json5 ).