### PR TITLE
Tiny I/O speed improvement using native functions

### DIFF
--- a/lua/vstask/Config.lua
+++ b/lua/vstask/Config.lua
@@ -1,12 +1,40 @@
+---@alias openmode
+---|>"r"   # Read mode.
+---| "w"   # Write mode.
+---| "a"   # Append mode.
+---| "r+"  # Update mode, all previous data is preserved.
+---| "w+"  # Update mode, all previous data is erased.
+---| "a+"  # Append update mode, previous data is preserved, writing is only allowed at the end of file.
+---| "rb"  # Read mode. (in binary mode.)
+---| "wb"  # Write mode. (in binary mode.)
+---| "ab"  # Append mode. (in binary mode.)
+---| "r+b" # Update mode, all previous data is preserved. (in binary mode.)
+---| "w+b" # Update mode, all previous data is erased. (in binary mode.)
+---| "a+b" # Append update mode, previous data is preserved, writing is only allowed at the end of file. (in binary mode.)
+
+--- read a file on disk
+---@param filePath string
+---@param mode? openmode
+---@return file*?
+---@return string? errmsg
+local readfile = function(filePath, mode)
+  mode = vim.F.if_nil(mode, "r")
+  local file = io.open(filePath, "r")
+  if file then
+    local data = file:read "*a"
+    file.close()
+    return data
+  end
+end
+
 --- Decodes from JSON.
 ---
----@param data string Data to decode
+---@param filepath string File on disk to decode
 ---@param parser function Parser to use
 ---@returns table json_obj Decoded JSON object
-local json_decode = function(data, parser)
-  local Parser = parser or vim.fn.json_decode
-  local lines = vim.fn.readfile(data)
-  local inputstr = table.concat(lines, '\n')
+local json_decode = function(filepath, parser)
+  local Parser = parser or vim.json.decode
+  local inputstr = readfile(filepath)
   local ok, result = pcall(Parser, inputstr)
   if ok then
     return result
@@ -18,7 +46,7 @@ end
 --- load settings from JSON file
 ---@param path string JSON file path
 ---@param parser function the parser to use
----@return boolean is_error if error then true
+---@return boolean? is_error if error then true
 local load_setting_json = function(path, parser)
   vim.validate {
     path = { path, 's' },

--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -130,7 +130,9 @@ local function create_cache(raw_list, key)
   local new_cache = {}
   for _, entry in pairs(raw_list) do
     local cache_key = entry[key]
-    new_cache[cache_key] = {entry = entry, hits = 0, timestamp = os.time()}
+    if cache_key then
+      new_cache[cache_key] = {entry = entry, hits = 0, timestamp = os.time()}
+    end
   end
   return new_cache
 end


### PR DESCRIPTION
This PR should not negatively impact existing configurations, but it makes a few changes to the existing implementation:

The default JSON parser switches from vim's `json_decode()` to neovim's (faster) `vim.json.decode()`.

`readfile(<filepath>)` can be safely replaced by lua's `io` library (i.e. `io.open(<filepath>, <open_mode>)`