### PR TITLE
feat(jobs): jobs picker now shows all jobs with live previews and standard term output

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,12 @@
   ],
   "tasks": [
     {
+      "command": "echo moooo | cowsay",
+      "label": "🐮 Cowsay No Input",
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
       "command": "echo ${input:phrase} | cowsay",
       "label": "🐮 Cowsay",
       "problemMatcher": [],

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Telescope plugin to load and run tasks in a project that conform to VS Code's [E
 - Use VS Code's [variables](https://code.visualstudio.com/docs/editor/variables-reference) in the command (limited support, see desired features)
 - Use VS Code's [launch.json](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) pattern (limited support)
 - ⟳ Run tasks from your history, sorted by most used
-- 🐚 run shell commands with .run() or <C-r>
+- 🐚 run shell commands with .run() or `<C-r>`
 - basic support for option picker for task input (similar to extension.commandvariable.pickStringRemember)
 - dependsOn and dependsOrder support, utilizing the background jobs feature. View with Jobs picker
 - add default tasks in setup for projects without .vscode/tasks.json, or of you want to add your own

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Telescope plugin to load and run tasks in a project that conform to VS Code's [E
 - 🐚 run shell commands with .run() or <C-r>
 - basic support for option picker for task input (similar to extension.commandvariable.pickStringRemember)
 - dependsOn and dependsOrder support, utilizing the background jobs feature. View with Jobs picker
+- add default tasks in setup for projects without .vscode/tasks.json, or of you want to add your own
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Telescope plugin to load and run tasks in a project that conform to VS Code's [E
 
 ## Features
 
-- ⚙ Run commands in a terminal!
+- ⚙ Run commands in a terminal as jobs!
   - split or float the terminal
   - source from ./vscode/tasks.json
   - source from package.json scripts
+- With jobs picker, see all running and completed jobs, including a live output preview
 - 👀 Run any task as a watched job
 - 🧵 Run any task in the background as a job
 - 📖 Browse history of completed background jobs

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Telescope plugin to load and run tasks in a project that conform to VS Code's [E
 - ⟳ Run tasks from your history, sorted by most used
 - 🐚 run shell commands with .run() or <C-r>
 - basic support for option picker for task input (similar to extension.commandvariable.pickStringRemember)
-- dependsOn and dependsOrder support, utilizing the background jobs feature. View with JobHistory and Jobs
+- dependsOn and dependsOrder support, utilizing the background jobs feature. View with Jobs picker
 
 ## Example
 
@@ -67,10 +67,10 @@ Set up keybindings:
 ```vim
 nnoremap <Leader>ta :lua require("telescope").extensions.vstask.tasks()<CR>
 nnoremap <Leader>ti :lua require("telescope").extensions.vstask.inputs()<CR>
+nnoremap <Leader>tj :lua require("telescope").extensions.vstask.jobs()<CR>
 nnoremap <Leader>tc :lua require("telescope").extensions.vstask.clear_inputs()<CR>
 nnoremap <Leader>th :lua require("telescope").extensions.vstask.history()<CR>
 nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
-nnoremap <Leader>tj :lua require("telescope").extensions.vstask.jobs()<CR>
 ```
 
 ## Functions
@@ -325,9 +325,9 @@ In your project root set up `.vscode/tasks.json` (default config directory set t
 ```lua
 lua require("telescope").extensions.vstask.tasks() -- open task list in telescope
 lua require("telescope").extensions.vstask.inputs() -- open the input list, set new input
+lua require("telescope").extensions.vstask.jobs() -- view and manage all jobs (running and completed)
 lua require("telescope").extensions.vstask.history() -- search history of tasks
 lua require("telescope").extensions.vstask.close() -- close the task runner (if toggleterm)
-lua require("telescope").extensions.vstask.jobs() -- view and manage all tasks (running and completed)
 lua require("telescope").extensions.vstask.run() -- open menu to type cli cmd and run it with standard bindings
 ```
 
@@ -363,11 +363,9 @@ All [variables available in VS Code](https://code.visualstudio.com/docs/editor/v
 At this point only the features I need professionally have been implemented.
 The implemented schema elements are as follows:
 
-- [x] Tasks: Label
-- [x] Tasks: Command
-- [x] Tasks: ID
-- [x] Inputs: Description
-- [x] Inputs: Default
+- [] dependsOn visual layouts
+- [] problemMatcher
+- [] auto run job on opening certain files
 
 As I do not use VS Code, the current implementation are the elements that seem
 most immediately useful. In the future it may be good to look into implementing

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ Set up keybindings:
 nnoremap <Leader>ta :lua require("telescope").extensions.vstask.tasks()<CR>
 nnoremap <Leader>ti :lua require("telescope").extensions.vstask.inputs()<CR>
 nnoremap <Leader>tj :lua require("telescope").extensions.vstask.jobs()<CR>
-nnoremap <Leader>tc :lua require("telescope").extensions.vstask.clear_inputs()<CR>
-nnoremap <Leader>th :lua require("telescope").extensions.vstask.history()<CR>
+nnoremap <Leader>td :lua require("telescope").extensions.vstask.clear_inputs()<CR>
+nnoremap <Leader>tc :lua require("telescope").extensions.vstask.cleanup_completed_jobs()<CR>
 nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
+nnoremap <Leader>tl :lua require('telescope').extensions.vstask.command()<cr>
 ```
 
 ## Functions
@@ -81,7 +82,8 @@ nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
 
 `:Telescope vstask tasks`
 
-- Opens task picker showing all available tasks from `.vscode/tasks.json` and `package.json` scripts
+- Opens task picker showing all available tasks from `.vscode/tasks.json`
+- Also can load language specific of `default_tasks` based on config
 - Key mappings:
   - `<CR>` - Run in current window
   - `<C-v>` - Run in vertical split
@@ -103,11 +105,6 @@ nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
   - promptString (text input)
   - pickString (selection from list)
 
-`:Telescope vstask history`
-
-- Shows previously run tasks, sorted by usage frequency
-- Supports same key mappings as tasks
-
 `:Telescope vstask launch`
 
 - Opens launch configuration picker from `.vscode/launch.json`
@@ -116,6 +113,7 @@ nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
   - `<C-v>` - Run in vertical split
   - `<C-p>` - Run in horizontal split
   - `<C-t>` - Run in new tab
+  - `<C-b>` - Run in background terminal (hidden from buffers)
 
 ### Job Management
 
@@ -127,7 +125,7 @@ nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
   - `<C-v>` - View output in vertical split
   - `<C-p>` - View output in horizontal split
   - `<C-w>` - Toggle watch mode (restart on save)
-  - `<C-d>` - Kill task/Remove from history
+  - `<C-d>` - Kill task and remove from job list
 - Features:
   - Live output preview
   - Watch mode for auto-restart
@@ -143,6 +141,10 @@ nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
 `:Telescope vstask clear_inputs`
 
 - Clears all stored input variable values for current session
+
+`:Telescope vstask cleanup_completed_jobs`
+
+- Removes all completed jobs from the job list
 
 ### Autodetect
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ scripts.
   is removed, this will also remove cache features such as remembering last
   ran command
 
+Make sure to load the plugin in your telescope config
+
+```lua
+require("telescope").load_extension("vstask")
+```
+
 ```lua
 lua <<EOF
 require("vstask").setup({

--- a/README.md
+++ b/README.md
@@ -67,11 +67,10 @@ Set up keybindings:
 ```vim
 nnoremap <Leader>ta :lua require("telescope").extensions.vstask.tasks()<CR>
 nnoremap <Leader>ti :lua require("telescope").extensions.vstask.inputs()<CR>
-nnoremap <Leader>ti :lua require("telescope").extensions.vstask.clear_inputs()<CR>
+nnoremap <Leader>tc :lua require("telescope").extensions.vstask.clear_inputs()<CR>
 nnoremap <Leader>th :lua require("telescope").extensions.vstask.history()<CR>
 nnoremap <Leader>tl :lua require('telescope').extensions.vstask.launch()<cr>
 nnoremap <Leader>tj :lua require("telescope").extensions.vstask.jobs()<CR>
-nnoremap <Leader>t; :lua require("telescope").extensions.vstask.jobhistory()<CR>
 ```
 
 ## Functions
@@ -86,8 +85,8 @@ nnoremap <Leader>t; :lua require("telescope").extensions.vstask.jobhistory()<CR>
   - `<C-v>` - Run in vertical split
   - `<C-p>` - Run in horizontal split
   - `<C-t>` - Run in new tab
-  - `<C-b>` - Run as background job
-  - `<C-w>` - Run as watched background job (restarts on file save)
+  - `<C-b>` - Run in background terminal
+  - `<C-w>` - Run as watched job (restarts on file save)
 
 `:Telescope vstask run`
 
@@ -120,27 +119,22 @@ nnoremap <Leader>t; :lua require("telescope").extensions.vstask.jobhistory()<CR>
 
 `:Telescope vstask jobs`
 
-- Shows running background tasks
+- Shows all jobs (running and completed)
 - Key mappings:
   - `<CR>` - View output in current window
   - `<C-v>` - View output in vertical split
+  - `<C-p>` - View output in horizontal split
   - `<C-w>` - Toggle watch mode (restart on save)
-  - `<C-d>` - Kill task
+  - `<C-d>` - Kill task/Remove from history
 - Features:
   - Live output preview
   - Watch mode for auto-restart
-  - Task status indicators
-
-`:Telescope vstask jobhistory`
-
-- Shows completed background tasks
-- Key mappings:
-  - `<CR>` - View output in current window
-  - `<C-v>` - View output in vertical split
-- Features:
-  - Exit status indication
-  - Runtime duration
-  - Full output history
+  - Task status indicators (🟠 running, 🟢 success, 🔴 failed)
+  - 👀 Watch indicator for watched tasks
+  - Smart sorting: Recently selected tasks appear first
+  - Runtime duration tracking
+  - Exit code display for completed tasks
+  - Terminal buffer management
 
 ### Utility Functions
 
@@ -333,7 +327,7 @@ lua require("telescope").extensions.vstask.tasks() -- open task list in telescop
 lua require("telescope").extensions.vstask.inputs() -- open the input list, set new input
 lua require("telescope").extensions.vstask.history() -- search history of tasks
 lua require("telescope").extensions.vstask.close() -- close the task runner (if toggleterm)
-lua require("telescope").extensions.vstask.jobs() -- view and manage background tasks (Enter to kill)
+lua require("telescope").extensions.vstask.jobs() -- view and manage all tasks (running and completed)
 lua require("telescope").extensions.vstask.run() -- open menu to type cli cmd and run it with standard bindings
 ```
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ require("vstask").setup({
           label = " npm install",
           type = "shell",
           command = "npm i",
-          filetypes = { "typescript" }, -- leave blank for always adding
+          filetypes = { "typescript" }, -- remove field to always add
         },
       },
 })

--- a/README.md
+++ b/README.md
@@ -192,7 +192,15 @@ require("vstask").setup({
       direction = 'tab',
     }
   },
-  json_parser = vim.json.decode
+  json_parser = vim.json.decode,
+  default_tasks = {
+        {
+          label = " npm install",
+          type = "shell",
+          command = "npm i",
+          filetypes = { "typescript" }, -- leave blank for always adding
+        },
+      },
 })
 EOF
 ```

--- a/lua/telescope/_extensions/vstask.lua
+++ b/lua/telescope/_extensions/vstask.lua
@@ -4,13 +4,11 @@ local Telescope = require("vstask.Telescope")
 return require("telescope").register_extension({
 	exports = {
 		tasks = Telescope.Tasks,
-		run = Telescope.Tasks_empty,
 		inputs = Telescope.Inputs,
 		history = Telescope.History,
 		launch = Telescope.Launch,
-		close = Telescope.Close,
 		jobs = Telescope.Jobs,
-		jobhistory = Telescope.JobHistory,
 		clear_inputs = Parse.Clear_inputs,
+		cleanup_completed_jobs = Telescope.cleanup_completed_jobs,
 	},
 })

--- a/lua/telescope/_extensions/vstask.lua
+++ b/lua/telescope/_extensions/vstask.lua
@@ -1,8 +1,10 @@
 local Parse = require("vstask.Parse")
 local Telescope = require("vstask.Telescope")
 local Jobs = require("vstask.Job")
+local telescope = require("telescope")
 
-return require("telescope").register_extension({
+local M = telescope.register_extension({
+	setup = require("vstask").setup,
 	exports = {
 		tasks = Telescope.Tasks,
 		inputs = Telescope.Inputs,
@@ -14,3 +16,5 @@ return require("telescope").register_extension({
 		command = Telescope.Command,
 	},
 })
+
+return M

--- a/lua/telescope/_extensions/vstask.lua
+++ b/lua/telescope/_extensions/vstask.lua
@@ -1,5 +1,6 @@
 local Parse = require("vstask.Parse")
 local Telescope = require("vstask.Telescope")
+local Jobs = require("vstask.Jobs")
 
 return require("telescope").register_extension({
 	exports = {
@@ -9,6 +10,6 @@ return require("telescope").register_extension({
 		launch = Telescope.Launch,
 		jobs = Telescope.Jobs,
 		clear_inputs = Parse.Clear_inputs,
-		cleanup_completed_jobs = Telescope.cleanup_completed_jobs,
+		cleanup_completed_jobs = Jobs.cleanup_completed_jobs,
 	},
 })

--- a/lua/telescope/_extensions/vstask.lua
+++ b/lua/telescope/_extensions/vstask.lua
@@ -11,5 +11,6 @@ return require("telescope").register_extension({
 		jobs = Telescope.Jobs,
 		clear_inputs = Parse.Clear_inputs,
 		cleanup_completed_jobs = Jobs.cleanup_completed_jobs,
+		command = Telescope.Command,
 	},
 })

--- a/lua/telescope/_extensions/vstask.lua
+++ b/lua/telescope/_extensions/vstask.lua
@@ -1,6 +1,6 @@
 local Parse = require("vstask.Parse")
 local Telescope = require("vstask.Telescope")
-local Jobs = require("vstask.Jobs")
+local Jobs = require("vstask.Job")
 
 return require("telescope").register_extension({
 	exports = {

--- a/lua/vstask/Config.lua
+++ b/lua/vstask/Config.lua
@@ -1,4 +1,3 @@
----@alias openmode
 ---|>"r"   # Read mode.
 ---| "w"   # Write mode.
 ---| "a"   # Append mode.
@@ -22,7 +21,7 @@ local readfile = function(filePath, mode)
 	local file = io.open(filePath, "r")
 	if file then
 		local data = file:read("*a")
-		file.close()
+		file.close(file)
 		return data
 	end
 end

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -491,7 +491,7 @@ M.job_selected = function(job_id)
 	job_last_selected[job_id] = os.time()
 end
 
-M.compare_last_selected = function(job_a, job_b)
+local compare_last_selected = function(job_a, job_b)
 	if job_last_selected[job_a] and job_last_selected[job_b] then
 		return job_last_selected[job_a] > job_last_selected[job_b]
 		-- If only one job has been selected, prioritize it
@@ -530,7 +530,7 @@ M.build_jobs_list = function()
 
 	-- Sort jobs by last selected time, falling back to start time
 	table.sort(jobs_list, function(a, b)
-		return M.compare_last_selected(a.id, b.id)
+		return compare_last_selected(a.id, b.id)
 	end)
 
 	return jobs_list

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -86,6 +86,21 @@ local function get_buf_counter(label)
 	end
 end
 
+local get_unique_label = function(label)
+	local counter = 1
+	for _, job in pairs(M.get_background_jobs()) do
+		if string.find(job.label, label) then
+			counter = counter + 1
+		end
+	end
+	if counter == 1 then
+		return label
+	else
+		local unique_label = label .. " (" .. counter .. ")"
+		return unique_label
+	end
+end
+
 local function name_buffer(buf, label)
 	local name = get_buf_counter(label)
 	vim.api.nvim_buf_set_name(buf, name)
@@ -133,7 +148,7 @@ end
 M.start_job = function(opts)
 	-- Default options
 	local options = {
-		label = opts.label,
+		label = get_unique_label(opts.label),
 		command = opts.command,
 		silent = opts.silent or false,
 		watch = opts.watch or false,

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -185,6 +185,7 @@ M.start_job = function(opts)
 		silent = opts.silent or false,
 		watch = opts.watch or false,
 		on_complete = opts.on_complete,
+		on_data = opts.on_data,
 		terminal = opts.terminal == nil and true or opts.terminal,
 		direction = opts.direction or "current",
 	}
@@ -247,6 +248,9 @@ M.start_job = function(opts)
 		pty = true,
 		on_stdout = function(_, data)
 			if data then
+				if options.on_data then
+					options.on_data(data)
+				end
 				update_buffers()
 			end
 		end,

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -55,6 +55,13 @@ M.clean_command = function(pre, options)
 	return command
 end
 
+-- Just trigger the update event, let preview system handle the display
+local update_buffers = function()
+	vim.schedule(function()
+		vim.api.nvim_exec_autocmds("User", { pattern = "VsTaskJobOutput" })
+	end)
+end
+
 -- Helper function to find a task by label
 local function find_task_by_label(label, task_list)
 	for _, task in ipairs(task_list) do
@@ -230,18 +237,12 @@ M.start_job = function(opts)
 		pty = true,
 		on_stdout = function(_, data)
 			if data then
-				-- Just trigger the update event, let preview system handle the display
-				vim.schedule(function()
-					vim.api.nvim_exec_autocmds("User", { pattern = "VsTaskJobOutput" })
-				end)
+				update_buffers()
 			end
 		end,
 		on_stderr = function(_, data)
 			if data then
-				-- Just trigger the update event, let preview system handle the display
-				vim.schedule(function()
-					vim.api.nvim_exec_autocmds("User", { pattern = "VsTaskJobOutput" })
-				end)
+				update_buffers()
 			end
 		end,
 		on_exit = function(_, exit_code)
@@ -251,10 +252,7 @@ M.start_job = function(opts)
 				return
 			end
 
-			vim.schedule(function()
-				-- Just trigger the final update event
-				vim.api.nvim_exec_autocmds("User", { pattern = "VsTaskJobOutput" })
-			end)
+			update_buffers()
 
 			if exit_code == 0 then
 				notify("🟢 Job completed successfully : " .. job.label, vim.log.levels.INFO)
@@ -561,6 +559,7 @@ M.configure_preview = function(preview_key, job_id, preview_buffer)
 			vim.bo[preview_buffer].modifiable = true
 			vim.api.nvim_buf_set_lines(preview_buffer, 0, -1, false, { "Starting job, waiting for output..." })
 		end
+		update_buffers()
 	end)
 end
 

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -507,27 +507,28 @@ M.job_selected = function(job_id)
 end
 
 local compare_last_selected = function(job_a, job_b)
-	local last_a = job_last_selected[job_a]
-	local last_b = job_last_selected[job_b]
 	local background_a = background_jobs[job_a]
 	local background_b = background_jobs[job_b]
+
+	-- First prioritize running jobs over completed ones
+	if background_a.completed ~= background_b.completed then
+		return not background_a.completed -- Running jobs (not completed) come first
+	end
+
+	-- If both are running or both are completed, use last selected time
+	local last_a = job_last_selected[job_a]
+	local last_b = job_last_selected[job_b]
+
 	if last_a and last_b then
-		if background_a.completed and background_b.completed then
-			return last_a > last_b
-		else
-			if background_a.completed then
-				return false
-			elseif background_b.completed then
-				return false
-			end
-		end
-		-- If only one job has been selected, prioritize it
+		return last_a > last_b
 	elseif last_a then
 		return true
 	elseif last_b then
 		return false
 	end
-	return background_jobs[job_a].start_time > background_jobs[job_b].start_time
+
+	-- If neither has been selected, sort by start time
+	return background_a.start_time > background_b.start_time
 end
 
 M.is_preview_configured = function(preview_key)

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -521,6 +521,21 @@ M.configure_preview = function(preview_key, job_id, preview_buffer)
 	end)
 end
 
+-- Build a sorted list of jobs
+M.build_jobs_list = function()
+	local jobs_list = {}
+	for _, job_info in pairs(M.get_background_jobs()) do
+		table.insert(jobs_list, job_info)
+	end
+
+	-- Sort jobs by last selected time, falling back to start time
+	table.sort(jobs_list, function(a, b)
+		return M.compare_last_selected(a.id, b.id)
+	end)
+
+	return jobs_list
+end
+
 M.fully_clear_job = function(job_id)
 	-- Remove from tracking tables
 	if live_output_buffers[job_id] then

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -1,0 +1,554 @@
+local Opts = require("vstask.Opts")
+local Parse = require("vstask.Parse")
+local quickfix = require("vstask.Quickfix")
+local M = {}
+
+local background_jobs = {}
+local live_output_buffers = {} -- Track buffers showing live job output
+local preview_configured = {}
+local job_last_selected = {}
+
+local Term_opts = {}
+
+M.LABEL_PRE = "Task: "
+
+M.split_to_direction = function(direction)
+	local opt_direction = Opts.get_direction(direction, Term_opts)
+	local size = Opts.get_size(direction, Term_opts)
+	local command_map = {
+		vertical = { size = "vertical resize", command = "vsplit" },
+		horizontal = { size = "resize ", command = "split" },
+		tab = { command = "tabnew" },
+	}
+
+	if command_map[opt_direction] ~= nil then
+		vim.cmd(command_map[opt_direction].command)
+		if command_map[opt_direction].size ~= nil and size ~= nil then
+			vim.cmd(command_map[opt_direction].size .. size)
+		end
+	end
+end
+
+M.is_job_running = function(job_id)
+	return job_id and background_jobs[job_id].completed ~= true
+end
+
+M.scroll_to_bottom = function(win_id)
+	if win_id and win_id ~= -1 then
+		local buf = vim.api.nvim_win_get_buf(win_id)
+		local line_count = vim.api.nvim_buf_line_count(buf)
+		if line_count > 0 then
+			vim.api.nvim_win_set_cursor(win_id, { line_count, 0 })
+		end
+	end
+end
+
+M.clean_command = function(pre, options)
+	local command = pre
+	if type(options) == "table" then
+		local cwd = options["cwd"]
+		if type(cwd) == "string" then
+			local cd_command = string.format("cd %s", cwd)
+			command = string.format("%s && %s", cd_command, command)
+		end
+	end
+	return command
+end
+
+-- Helper function to find a task by label
+local function find_task_by_label(label, task_list)
+	for _, task in ipairs(task_list) do
+		if task.label == label then
+			return task
+		end
+	end
+	return nil
+end
+
+local function get_buf_counter(label)
+	local base_name = M.LABEL_PRE .. label
+	local max_counter = 1
+
+	-- Find highest existing counter and check for base name
+	for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(buf_id) then
+			local buf_name = vim.api.nvim_buf_get_name(buf_id)
+			if string.find(buf_name, base_name) then
+				max_counter = max_counter + 1
+			end
+		end
+	end
+
+	if max_counter == 1 then
+		return base_name
+	else
+		return base_name .. " (" .. max_counter .. ")"
+	end
+end
+
+local function name_buffer(buf, label)
+	local name = get_buf_counter(label)
+	vim.api.nvim_buf_set_name(buf, name)
+end
+
+-- Function to get terminal buffer content
+M.get_buffer_content = function(buf_job_id)
+	-- Check if job exists
+	if not buf_job_id then
+		return {}
+	end
+
+	-- First try to find the job directly
+	local job = background_jobs[buf_job_id]
+
+	-- If not found directly, try to find by id field
+	if not job then
+		for job_id, j in pairs(background_jobs) do
+			if j.id == buf_job_id then
+				job = j
+				-- Update the job reference to use job_id as key
+				background_jobs[buf_job_id] = j
+				background_jobs[job_id] = nil
+				break
+			end
+		end
+	end
+
+	if not job then
+		return {}
+	end
+
+	-- Find the terminal buffer for this job
+	for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(buf_id) then
+			local buf_name = vim.api.nvim_buf_get_name(buf_id)
+			if buf_name:match(vim.pesc(M.LABEL_PRE .. job.label)) then
+				return vim.api.nvim_buf_get_lines(buf_id, 0, -1, false)
+			end
+		end
+	end
+	return {}
+end
+
+M.start_job = function(opts)
+	-- Default options
+	local options = {
+		label = opts.label,
+		command = opts.command,
+		silent = opts.silent or false,
+		watch = opts.watch or false,
+		on_complete = opts.on_complete,
+		terminal = opts.terminal == nil and true or opts.terminal,
+		direction = opts.direction or "current",
+	}
+
+	local function notify(msg, level)
+		if not options.silent then
+			vim.notify(msg, level, { title = "vs-tasks" })
+		end
+	end
+
+	if options.watch then
+		Add_watch_autocmd()
+	end
+
+	local job_id
+	local open_terminal = options.terminal
+
+	-- Create a new buffer for the terminal
+	local current_buf = vim.api.nvim_get_current_buf()
+	local buf = vim.api.nvim_create_buf(open_terminal, true)
+	if open_terminal == true then
+		M.split_to_direction(options.direction)
+	else
+		notify("Starting backgrounded task... " .. options.label, vim.log.levels.INFO)
+	end
+
+	-- show the buffer
+	vim.api.nvim_win_set_buf(0, buf)
+
+	-- Enable terminal scrolling and set buffer options
+	vim.api.nvim_create_autocmd("TermOpen", {
+		buffer = buf,
+		callback = function()
+			-- Set terminal options
+			vim.opt_local.scrolloff = 0
+
+			-- Apply buffer options from Parse if they exist
+			local buffer_options = Parse.buffer_options
+			if buffer_options then
+				local win = vim.api.nvim_get_current_win()
+				for _, option in ipairs(buffer_options) do
+					-- Set window-local options directly on the window
+					vim.wo[win][option] = true
+				end
+			end
+
+			-- Start in terminal mode
+			vim.cmd("startinsert")
+			-- Scroll to bottom
+			M.scroll_to_bottom(vim.api.nvim_get_current_win())
+		end,
+	})
+
+	-- Set buffer name after terminal creation
+	vim.schedule(function()
+		name_buffer(buf, options.label)
+	end)
+	job_id = vim.fn.jobstart(options.command, {
+		term = true,
+		pty = true,
+		on_stdout = function(_, data)
+			if data then
+				-- Just trigger the update event, let preview system handle the display
+				vim.schedule(function()
+					vim.api.nvim_exec_autocmds("User", { pattern = "VsTaskJobOutput" })
+				end)
+			end
+		end,
+		on_stderr = function(_, data)
+			if data then
+				-- Just trigger the update event, let preview system handle the display
+				vim.schedule(function()
+					vim.api.nvim_exec_autocmds("User", { pattern = "VsTaskJobOutput" })
+				end)
+			end
+		end,
+		on_exit = function(_, exit_code)
+			local job = background_jobs[job_id]
+
+			if job == nil then
+				return
+			end
+
+			vim.schedule(function()
+				-- Just trigger the final update event
+				vim.api.nvim_exec_autocmds("User", { pattern = "VsTaskJobOutput" })
+			end)
+
+			if exit_code == 0 then
+				notify("🟢 Job completed successfully : " .. job.label, vim.log.levels.INFO)
+				quickfix.close()
+			else
+				notify("🔴 Job failed." .. job.label, vim.log.levels.ERROR)
+				local content = M.get_buffer_content(job_id)
+				quickfix.toquickfix(content)
+			end
+
+			-- Always record end time and exit code
+			background_jobs[job_id].end_time = os.time()
+			background_jobs[job_id].exit_code = exit_code
+
+			-- Keep completed job in background_jobs unless it's a watch job
+			if not job.watch then
+				-- Get final output from terminal buffer
+				local content = M.get_buffer_content(job_id)
+				-- Update the job with final state
+				background_jobs[job_id] = {
+					id = job_id,
+					label = job.label,
+					end_time = os.time(),
+					start_time = job.start_time or os.time(),
+					exit_code = exit_code,
+					output = vim.deepcopy(content),
+					command = job.command,
+					completed = true, -- Mark as completed
+				}
+			end
+			if options.on_complete ~= nil then
+				options.on_complete()
+			end
+		end,
+	})
+
+	if options.terminal ~= true then
+		-- return to current buf if it's still valid
+		if vim.api.nvim_buf_is_valid(current_buf) then
+			vim.api.nvim_set_current_buf(current_buf)
+		end
+	end
+
+	if job_id <= 0 then
+		notify("Failed to start background job: " .. options.command, vim.log.levels.ERROR)
+	else
+		background_jobs[job_id] = {
+			id = job_id,
+			command = options.command,
+			start_time = os.time(),
+			output = M.get_buffer_content(job_id),
+			watch = options.watch,
+			label = options.label,
+			end_time = 0,
+			exit_code = -1,
+		}
+	end
+end
+
+-- Run dependent tasks sequentially in background
+M.run_dependent_tasks = function(task, task_list)
+	local deps = type(task.dependsOn) == "string" and { task.dependsOn } or task.dependsOn
+	local task_queue = {}
+
+	-- Run each dependent task
+	for _, dep_label in ipairs(deps) do
+		local dep_task = find_task_by_label(dep_label, task_list)
+		if dep_task then
+			local command = M.clean_command(dep_task.command, dep_task.options)
+			task_queue[#task_queue + 1] = { label = dep_task.label, command = command }
+		else
+			vim.notify("Dependent task not found: " .. dep_label, vim.log.levels.ERROR)
+		end
+	end
+	-- add the original task to the queue
+	if task.command ~= nil then
+		task_queue[#task_queue + 1] = { label = task.label, command = M.clean_command(task.command, task.options) }
+	end
+
+	local function report_done()
+		vim.notify("All dependent tasks completed", vim.log.levels.INFO)
+	end
+
+	local function run_next_task()
+		if #task_queue == 0 then
+			report_done()
+			return
+		end
+		local next_task = table.remove(task_queue, 1)
+		M.start_job({
+			label = next_task.label,
+			command = next_task.command,
+			silent = false,
+			watch = false,
+			on_complete = run_next_task,
+		})
+	end
+
+	local function run_all_tasks()
+		-- Run all tasks in parallel
+		for _, parallel_task in ipairs(task_queue) do
+			M.start_job({
+				label = parallel_task.label,
+				command = parallel_task.command,
+				silent = false,
+				watch = false,
+			})
+		end
+	end
+
+	if task.dependsOrder ~= nil and task.dependsOrder == "sequence" then
+		run_next_task()
+	else
+		run_all_tasks()
+	end
+end
+
+M.toggle_watch = function(job_id)
+	background_jobs[job_id].watch = not background_jobs[job_id].watch
+end
+
+M.preview_job_output = function(output, bufnr)
+	if not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+
+	-- Ensure output is a table
+	local lines = type(output) == "table" and output or {}
+
+	-- Get last 1000 lines
+	local max_lines = 1000
+	local start_idx = #lines > max_lines and #lines - max_lines or 0
+	local recent_output = vim.list_slice(lines, start_idx + 1)
+
+	-- Filter out empty lines and trim whitespace
+	local filtered_output = {}
+	local last_non_empty = 0
+	for i, line in ipairs(recent_output) do
+		-- Trim whitespace from both ends
+		line = vim.trim(line)
+		if line ~= "" and line ~= nil and not line:match("^%s*$") then
+			filtered_output[#filtered_output + 1] = line
+			last_non_empty = #filtered_output
+		elseif i < #recent_output then
+			-- Keep at most one empty line between content
+			filtered_output[#filtered_output + 1] = line
+		end
+	end
+
+	-- Trim trailing empty lines
+	if last_non_empty > 0 then
+		filtered_output = vim.list_slice(filtered_output, 1, last_non_empty)
+	end
+
+	-- Actually update the buffer content
+	pcall(function()
+		vim.bo[bufnr].modifiable = true
+		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, filtered_output)
+		vim.bo[bufnr].modifiable = false
+	end)
+
+	-- Scroll to bottom of the preview window
+	vim.schedule(function()
+		if not vim.api.nvim_buf_is_valid(bufnr) then
+			return
+		end
+
+		local preview_win = vim.fn.bufwinid(bufnr)
+		if preview_win ~= -1 then
+			local line_count = vim.api.nvim_buf_line_count(bufnr)
+			if line_count > 0 then
+				-- Set cursor to last line
+				pcall(function()
+					vim.api.nvim_win_set_cursor(preview_win, { line_count, 0 })
+					-- Make sure the last few lines are visible
+					vim.api.nvim_win_call(preview_win, function()
+						vim.cmd("normal! zb")
+					end)
+				end)
+			end
+		end
+	end)
+end
+
+-- Track preview configuration state per buffer+job combination
+M.get_preview_key = function(bufnr, job_id)
+	return string.format("%d_%d", bufnr, job_id)
+end
+
+-- Helper function to set up job output preview updates
+local function setup_preview_updates(bufnr, job_id)
+	if not (bufnr and job_id and M.is_job_running(job_id)) then
+		return
+	end
+
+	-- Clean up any existing autocmd group first
+	local group_name = string.format("VsTaskPreview_%d", job_id)
+	pcall(vim.api.nvim_del_augroup_by_name, group_name)
+
+	-- Create new augroup and autocmd
+	local group = vim.api.nvim_create_augroup(group_name, { clear = true })
+	vim.api.nvim_create_autocmd("User", {
+		group = group,
+		pattern = "VsTaskJobOutput",
+		callback = function()
+			if not vim.api.nvim_buf_is_valid(bufnr) then
+				pcall(vim.api.nvim_del_augroup_by_name, group_name)
+				live_output_buffers[job_id] = nil
+				return
+			end
+			local content = M.get_buffer_content(job_id)
+			if content then
+				M.preview_job_output(content, bufnr)
+			end
+		end,
+	})
+
+	-- Store the preview buffer in live_output_buffers
+	live_output_buffers[job_id] = bufnr
+
+	-- Set up cleanup when buffer is deleted
+	vim.api.nvim_buf_attach(bufnr, false, {
+		on_detach = function()
+			pcall(vim.api.nvim_del_augroup_by_name, group_name)
+			live_output_buffers[job_id] = nil
+			-- Clean up preview configuration state
+			preview_configured[M.get_preview_key(bufnr, job_id)] = nil
+		end,
+	})
+end
+
+M.get_background_jobs = function()
+	return background_jobs
+end
+
+M.get_background_job = function(job_id)
+	return background_jobs[job_id]
+end
+
+M.set_background_job = function(job_id, job)
+	background_jobs[job_id] = job
+end
+
+M.remove_background_job = function(job_id)
+	M.set_background_job(job_id, nil)
+end
+
+M.remove_background_jobs = function(jobs_to_remove)
+	for _, job_id in ipairs(jobs_to_remove) do
+		M.remove_background_job(job_id)
+	end
+end
+
+M.remove_live_buffer = function(job_id)
+	-- Remove from live_output_buffers if present
+	if live_output_buffers[job_id] then
+		if vim.api.nvim_buf_is_valid(live_output_buffers[job_id]) then
+			pcall(vim.api.nvim_buf_delete, live_output_buffers[job_id], { force = true })
+		end
+		live_output_buffers[job_id] = nil
+	end
+end
+M.job_selected = function(job_id)
+	job_last_selected[job_id] = os.time()
+end
+
+M.compare_last_selected = function(job_a, job_b)
+	if job_last_selected[job_a] and job_last_selected[job_b] then
+		return job_last_selected[job_a] > job_last_selected[job_b]
+		-- If only one job has been selected, prioritize it
+	elseif job_last_selected[job_a] then
+		return true
+	elseif job_last_selected[job_b] then
+		return false
+	end
+	return background_jobs[job_a].start_time > background_jobs[job_b].start_time
+end
+
+M.is_preview_configured = function(preview_key)
+	return preview_configured[preview_key]
+end
+
+M.configure_preview = function(preview_key, job_id, preview_buffer)
+	-- First time seeing this job
+	preview_configured[preview_key] = true
+	-- Set up live updates for this preview buffer
+	setup_preview_updates(preview_buffer, job_id)
+	-- Set initial message
+	vim.schedule(function()
+		if vim.api.nvim_buf_is_valid(preview_buffer) then
+			vim.bo[preview_buffer].modifiable = true
+			vim.api.nvim_buf_set_lines(preview_buffer, 0, -1, false, { "Starting job, waiting for output..." })
+		end
+	end)
+end
+
+M.fully_clear_job = function(job_id)
+	-- Remove from tracking tables
+	if live_output_buffers[job_id] then
+		live_output_buffers[job_id] = nil
+	end
+	if background_jobs[job_id] then
+		background_jobs[job_id] = nil
+	end
+	if job_last_selected[job_id] then
+		job_last_selected[job_id] = nil
+	end
+end
+
+M.open_buffer = function(label)
+	-- Find the terminal buffer for this job
+	for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(buf_id) then
+			local buf_name = vim.api.nvim_buf_get_name(buf_id)
+			if buf_name:match(vim.pesc(M.LABEL_PRE .. label)) then
+				vim.api.nvim_win_set_buf(0, buf_id)
+				-- Schedule scrolling to bottom to ensure buffer is loaded
+				vim.schedule(function()
+					M.scroll_to_bottom(vim.api.nvim_get_current_win())
+				end)
+				return
+			end
+		end
+	end
+end
+
+return M

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -362,6 +362,7 @@ M.run_dependent_tasks = function(task, task_list)
 			silent = false,
 			watch = false,
 			on_complete = run_next_task,
+			terminal = false,
 		})
 	end
 
@@ -373,6 +374,7 @@ M.run_dependent_tasks = function(task, task_list)
 				command = parallel_task.command,
 				silent = false,
 				watch = false,
+				terminal = false,
 			})
 		end
 	end

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -415,6 +415,18 @@ end
 
 M.toggle_watch = function(job_id)
 	background_jobs[job_id].watch = not background_jobs[job_id].watch
+	local job = M.get_background_job(job_id)
+	if job.watch then
+		M.fully_clear_job(job)
+		M.start_job({
+			label = job.label,
+			command = job.command,
+			silent = false,
+			watch = true,
+			terminal = false,
+			direction = "background_job",
+		})
+	end
 end
 
 M.preview_job_output = function(output, bufnr)

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -295,6 +295,9 @@ M.start_job = function(opts)
 			if exit_code == 0 then
 				notify("🟢 Job completed successfully : " .. job.label, vim.log.levels.INFO)
 				quickfix.close()
+			elseif job.watch == true then
+				local content = M.get_buffer_content(job_id)
+				quickfix.toquickfix(content)
 			else
 				notify("🔴 Job failed." .. job.label, vim.log.levels.ERROR)
 				local content = M.get_buffer_content(job_id)

--- a/lua/vstask/Job.lua
+++ b/lua/vstask/Job.lua
@@ -557,7 +557,6 @@ M.configure_preview = function(preview_key, job_id, preview_buffer)
 	vim.schedule(function()
 		if vim.api.nvim_buf_is_valid(preview_buffer) then
 			vim.bo[preview_buffer].modifiable = true
-			vim.api.nvim_buf_set_lines(preview_buffer, 0, -1, false, { "Starting job, waiting for output..." })
 		end
 		update_buffers()
 	end)

--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -3,6 +3,11 @@ local Config = require("vstask.Config")
 local Predefined = require("vstask.Predefined")
 
 local cache_json_conf = true
+local buffer_options = { "relativenumber" }
+
+local function set_buffer_options(opts)
+  buffer_options = opts
+end
 
 local function set_cache_json_conf(value)
 	cache_json_conf = value
@@ -524,4 +529,6 @@ return {
 	Set_config_dir = set_config_dir,
 	Set_json_parser = set_json_parser,
   Clear_inputs = clear_inputs,
+  Set_buffer_options = set_buffer_options,
+  buffer_options = buffer_options,
 }

--- a/lua/vstask/Quickfix.lua
+++ b/lua/vstask/Quickfix.lua
@@ -2,13 +2,40 @@ local M = {}
 
 function M.toquickfix(output)
 	vim.schedule(function()
-		local lines = vim.split(output, "\n")
+		local lines = type(output) == "table" and output or vim.split(output, "\n")
 		local qf_entries = {}
 
 		for _, line in ipairs(lines) do
-			-- Match TypeScript error format: file(line,col): error TS1234: message
-			local file, lnum, col, msg = line:match("([^%(]+)%((%d+),(%d+)%): (.+)")
+			-- Match TypeScript compiler error format (tsc)
+			-- Example: packages/service-graph-api/src/graphql.ts:28:3 - error TS2304: Cannot find name 'lol'.
+			local file, lnum, col, err_type, err_code, msg =
+				line:match("([^:]+):(%d+):(%d+)%s*%-%s*(%w+)%s*TS(%d+):%s*(.+)")
+
+			if file and msg then
+				msg = string.format("[TS%s] %s", err_code, msg)
+			end
+
+			-- If no match, try other formats
+			if not file then
+				-- Try TypeScript format with parentheses
+				file, lnum, col, msg = line:match("([^%(]+)%((%d+),(%d+)%): (.+)")
+			end
+
+			-- Fall back to ESLint format
+			if not file then
+				file, lnum, col, msg = line:match("([^:]+):(%d+):(%d+):%s*(.+)")
+			end
+
 			if file then
+				file = vim.trim(file)
+				-- Convert relative paths to absolute
+				if not vim.fn.filereadable(file) and vim.fn.getcwd() then
+					local abs_path = vim.fn.getcwd() .. "/" .. file
+					if vim.fn.filereadable(abs_path) then
+						file = abs_path
+					end
+				end
+
 				table.insert(qf_entries, {
 					filename = file,
 					lnum = tonumber(lnum),
@@ -19,13 +46,17 @@ function M.toquickfix(output)
 			end
 		end
 
-		vim.fn.setqflist(qf_entries)
-		local quickFixCount = #qf_entries
-
-		if quickFixCount > 0 then
+		if #qf_entries > 0 then
+			vim.fn.setqflist(qf_entries)
 			vim.cmd("copen")
+			local qf_height = math.min(10, #qf_entries)
+			vim.cmd("resize " .. qf_height)
 		end
 	end)
+end
+
+function M.close()
+	vim.cmd("cclose")
 end
 
 return M

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -398,39 +398,6 @@ local function format_jobs_list(jobs_list)
 	return jobs_formatted
 end
 
--- Function to clean up completed jobs and their buffers
-local function cleanup_completed_jobs()
-	local removed_count = 0
-
-	-- Collect jobs to remove (to avoid modifying table while iterating)
-	local jobs_to_remove = {}
-	for job_id, job_info in pairs(Job.get_background_jobs()) do
-		if job_info.completed then
-			-- Find and delete the buffer associated with this job
-			for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
-				if vim.api.nvim_buf_is_valid(buf_id) then
-					local buf_name = vim.api.nvim_buf_get_name(buf_id)
-					if buf_name:match(vim.pesc(Job.LABEL_PRE .. job_info.label)) then
-						pcall(vim.api.nvim_buf_delete, buf_id, { force = true })
-					end
-				end
-			end
-
-			-- Clean up autocmds if they exist
-			local group_name = string.format("VsTaskPreview_%d", job_id)
-			pcall(vim.api.nvim_del_augroup_by_name, group_name)
-
-			Job.remove_live_buffer(job_id)
-
-			-- Add to removal list
-			table.insert(jobs_to_remove, job_id)
-			removed_count = removed_count + 1
-		end
-	end
-
-	Job.remove_background_jobs(jobs_to_remove)
-end
-
 local function jobs_picker(opts)
 	opts = opts or {}
 
@@ -582,5 +549,4 @@ return {
 	Set_mappings = set_mappings,
 	Set_term_opts = set_term_opts,
 	Get_last = get_last,
-	cleanup_completed_jobs = cleanup_completed_jobs,
 }

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -73,7 +73,7 @@ local function inputs_picker(opts)
 			sorter = sorters.get_generic_fuzzy_sorter(),
 			attach_mappings = function(prompt_bufnr, map)
 				local start_task = function()
-					local selection = state.get_selected_entry(prompt_bufnr)
+					local selection = state.get_selected_entry()
 					actions.close(prompt_bufnr)
 
 					local input = selection_list[selection.index]["id"]
@@ -90,7 +90,7 @@ local function inputs_picker(opts)
 end
 
 local function handle_direction(direction, prompt_bufnr, selection_list, is_launch, opts)
-	local selection = state.get_selected_entry(prompt_bufnr)
+	local selection = state.get_selected_entry()
 	actions.close(prompt_bufnr)
 
 	local command, options, label, args
@@ -484,7 +484,7 @@ local function jobs_picker(opts)
 			}),
 			attach_mappings = function(prompt_bufnr, map)
 				local kill_job = function()
-					local selection = state.get_selected_entry(prompt_bufnr)
+					local selection = state.get_selected_entry()
 					local job = jobs_list[selection.index]
 					if not job or not job.id then
 						return
@@ -515,7 +515,7 @@ local function jobs_picker(opts)
 					local current_picker = state.get_current_picker(prompt_bufnr)
 
 					-- Rebuild and format jobs list
-					local updated_jobs_list = build_jobs_list()
+					local updated_jobs_list = Job.build_jobs_list()
 					local updated_jobs_formatted = format_jobs_list(updated_jobs_list)
 
 					-- Update the finder with new results
@@ -530,13 +530,13 @@ local function jobs_picker(opts)
 					jobs_list = updated_jobs_list
 				end
 				local toggle_watch_binding = function()
-					local selection = state.get_selected_entry(prompt_bufnr)
+					local selection = state.get_selected_entry()
 					local job = jobs_list[selection.index]
 					Job.toggle_watch(job.id)
 				end
 
 				local open_history = function()
-					local selection = state.get_selected_entry(prompt_bufnr)
+					local selection = state.get_selected_entry()
 					actions.close(prompt_bufnr)
 					local job = jobs_list[selection.index]
 					-- Update last selected time
@@ -545,7 +545,7 @@ local function jobs_picker(opts)
 				end
 
 				local open_vertical = function()
-					local selection = state.get_selected_entry(prompt_bufnr)
+					local selection = state.get_selected_entry()
 					actions.close(prompt_bufnr)
 					local job = jobs_list[selection.index]
 					-- Update last selected time
@@ -555,7 +555,7 @@ local function jobs_picker(opts)
 				end
 
 				local open_horizontal = function()
-					local selection = state.get_selected_entry(prompt_bufnr)
+					local selection = state.get_selected_entry()
 					actions.close(prompt_bufnr)
 					local job = jobs_list[selection.index]
 					-- Update last selected time

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -105,6 +105,9 @@ local function command_input(opts)
 					watch = direction == "watch_job",
 					terminal = direction ~= "background_job",
 					direction = direction,
+					on_complete = function()
+						refresh_picker()
+					end,
 				})
 
 				-- Schedule the mode change to happen after the input is processed
@@ -533,25 +536,8 @@ local function jobs_picker(opts)
 
 				local job = Job.get_background_job(selected_job.id)
 
-				Job.fully_clear_job(job.id)
-
-				-- Update the picker's job list
-				local current_picker = state.get_current_picker(prompt_bufnr)
-
-				-- Rebuild and format jobs list
-				local updated_jobs_list = Job.build_jobs_list()
-				local updated_jobs_formatted = format_jobs_list(updated_jobs_list)
-
-				-- Update the finder with new results
-				current_picker:refresh(
-					finders.new_table({
-						results = updated_jobs_formatted,
-					}),
-					{ reset_prompt = false }
-				)
-
-				-- Update the reference to jobs_list for the picker
-				jobs_list = updated_jobs_list
+				Job.fully_clear_job(job)
+				refresh_picker()
 			end
 			local toggle_watch_binding = function()
 				local selection = state.get_selected_entry()
@@ -584,7 +570,6 @@ local function jobs_picker(opts)
 				local job = jobs_list[selection.index]
 				-- Update last selected time
 				Job.job_selected(job.id)
-				vim.notify("selecting job: " .. job.label)
 				Job.split_to_direction("horizontal")
 				Job.open_buffer(job.label)
 			end

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -401,7 +401,7 @@ local function preview_job_output(output, bufnr, job_id)
 	end
 end
 
-local function inputs(opts)
+local function inputs_picker(opts)
 	opts = opts or {}
 
 	local input_list = Parse.Inputs()
@@ -540,7 +540,7 @@ local function start_task_direction(direction, prompt_bufnr, _, selection_list, 
 	handle_direction(direction, prompt_bufnr, selection_list, false, opts)
 end
 
-local function tasks(opts)
+local function tasks_picker(opts)
 	opts = opts or {}
 
 	local task_list = Parse.Tasks()
@@ -600,13 +600,7 @@ local function tasks(opts)
 		:find()
 end
 
-local function tasks_empty(opts)
-	opts = opts or {}
-	opts.run_empty = true
-	tasks(opts)
-end
-
-local function launches(opts)
+local function launches_picker(opts)
 	opts = opts or {}
 
 	local launch_list = Parse.Launches()
@@ -789,7 +783,7 @@ local function open_buffer(label)
 	end
 end
 
-local function background_jobs_list(opts)
+local function jobs_picker(opts)
 	opts = opts or {}
 
 	local jobs_list = {}
@@ -901,11 +895,10 @@ local function background_jobs_list(opts)
 end
 
 return {
-	Launch = launches,
-	Tasks = tasks,
-	Tasks_empty = tasks_empty,
-	Inputs = inputs,
-	Jobs = background_jobs_list,
+	Launch = launches_picker,
+	Tasks = tasks_picker,
+	Inputs = inputs_picker,
+	Jobs = jobs_picker,
 	Set_mappings = set_mappings,
 	Set_term_opts = set_term_opts,
 	Get_last = get_last,

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -413,8 +413,6 @@ local function preview_job_output(output, bufnr)
 		vim.bo[bufnr].modifiable = true
 		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, filtered_output)
 		vim.bo[bufnr].modifiable = false
-		-- Set filetype to help with syntax highlighting
-		vim.bo[bufnr].filetype = "sh"
 	end)
 
 	-- Scroll to bottom of the preview window
@@ -1008,6 +1006,7 @@ local function jobs_picker(opts)
 						if type(output) == "string" then
 							output = vim.split(output, "\n")
 						end
+						vim.bo[self.state.bufnr].filetype = "sh"
 						preview_job_output(output, self.state.bufnr)
 					end
 				end,

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -388,21 +388,6 @@ local function format_job_entry(job_info, is_running)
 	return formatted
 end
 
--- Build a sorted list of jobs
-local function build_jobs_list()
-	local jobs_list = {}
-	for _, job_info in pairs(Job.get_background_jobs()) do
-		table.insert(jobs_list, job_info)
-	end
-
-	-- Sort jobs by last selected time, falling back to start time
-	table.sort(jobs_list, function(a, b)
-		return Job.compare_last_selected(a.id, b.id)
-	end)
-
-	return jobs_list
-end
-
 -- Format the jobs list for display
 local function format_jobs_list(jobs_list)
 	local jobs_formatted = {}
@@ -449,7 +434,7 @@ end
 local function jobs_picker(opts)
 	opts = opts or {}
 
-	local jobs_list = build_jobs_list()
+	local jobs_list = Job.build_jobs_list()
 	local jobs_formatted = format_jobs_list(jobs_list)
 
 	if vim.tbl_isempty(jobs_formatted) then

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -472,7 +472,6 @@ local function handle_direction(direction, prompt_bufnr, selection_list, is_laun
 		options = nil
 		label = "CMD: " .. current_line
 		args = nil
-		set_history(label, command, options)
 	elseif is_launch then
 		command = selection_list[selection.index]["program"]
 		options = selection_list[selection.index]["options"]
@@ -484,7 +483,6 @@ local function handle_direction(direction, prompt_bufnr, selection_list, is_laun
 		options = selection_list[selection.index]["options"]
 		label = selection_list[selection.index]["label"]
 		args = selection_list[selection.index]["args"]
-		set_history(label, command, options)
 	end
 
 	local cleaned = clean_command(command, options)

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -845,6 +845,8 @@ local function jobs_picker(opts)
 					if is_running then
 						-- Kill the running job
 						vim.fn.jobstop(job.id)
+						-- Remove from background_jobs
+						background_jobs[job.id] = nil
 						vim.notify(string.format("Killed job %d: %s", job.id, job.command), vim.log.levels.INFO)
 					end
 
@@ -858,9 +860,6 @@ local function jobs_picker(opts)
 							end
 						end
 					end
-
-					-- Remove from background_jobs
-					background_jobs[job.id] = nil
 
 					-- Remove from live_output_buffers if present
 					if live_output_buffers[job.id] then

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -808,13 +808,13 @@ local function jobs_picker(opts)
 
 	pickers
 		.new(opts, {
-			prompt_title = "Background Jobs",
+			prompt_title = "Jobs",
 			finder = finders.new_table({
 				results = jobs_formatted,
 			}),
 			sorter = sorters.get_generic_fuzzy_sorter(),
 			previewer = previewers.new_buffer_previewer({
-				title = "Job Output",
+				title = "Jobs",
 				define_preview = function(self, entry)
 					local job = jobs_list[entry.index]
 					if not job then

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -290,7 +290,7 @@ local function handle_direction(direction, prompt_bufnr, selection_list, is_laun
 			command = prepared_command,
 			silent = false,
 			watch = direction == "watch_job",
-			terminal = direction ~= "background_job",
+			terminal = direction ~= "background_job" and direction ~= "watch_job",
 			direction = direction,
 			on_complete = function()
 				refresh_picker()
@@ -447,7 +447,7 @@ local function restart_watched_jobs()
 			-- Use timer to ensure job is fully stopped before restarting
 			if not Job.is_running(job_id) then
 				-- Remove from background_jobs to prevent duplicate entries
-				Job.set_background_jobs(job_id, nil)
+				Job.set_background_job(job_id, nil)
 
 				-- Remove from live_output_buffers if present
 				Job.remove_live_output_buffer(job_id)

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -426,6 +426,9 @@ local function restart_watched_jobs()
 						silent = false,
 						watch = true,
 						terminal = false, -- Start in background
+						on_complete = function()
+							refresh_picker()
+						end,
 					})
 				end)
 			else

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -394,7 +394,7 @@ local function preview_job_output(output, bufnr)
 	for i, line in ipairs(recent_output) do
 		-- Trim whitespace from both ends
 		line = vim.trim(line)
-		if line ~= "" then
+		if line ~= "" and line ~= nil and not line:match("^%s*$") then
 			filtered_output[#filtered_output + 1] = line
 			last_non_empty = #filtered_output
 		elseif i < #recent_output then
@@ -1002,7 +1002,8 @@ local function jobs_picker(opts)
 						end
 					else
 						-- For completed jobs, use stored output
-						local output = job.output or {}
+						local background_job = background_jobs[job.id]
+						local output = background_job.output or {}
 						if type(output) == "string" then
 							output = vim.split(output, "\n")
 						end

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -134,12 +134,23 @@ local start_job = function(opts)
 	-- show the buffer
 	vim.api.nvim_win_set_buf(0, buf)
 
-	-- Enable terminal scrolling
+	-- Enable terminal scrolling and set buffer options
 	vim.api.nvim_create_autocmd("TermOpen", {
 		buffer = buf,
 		callback = function()
 			-- Set terminal options
 			vim.opt_local.scrolloff = 0
+
+			-- Apply buffer options from Parse if they exist
+			local buffer_options = Parse.buffer_options
+			if buffer_options then
+				local win = vim.api.nvim_get_current_win()
+				for _, option in ipairs(buffer_options) do
+					-- Set window-local options directly on the window
+					vim.wo[win][option] = true
+				end
+			end
+
 			-- Start in terminal mode
 			vim.cmd("startinsert")
 			-- Scroll to bottom

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -541,6 +541,11 @@ local function handle_direction(direction, prompt_bufnr, selection_list, is_laun
 		end
 	end
 
+	-- Update task usage tracking before running
+	if task then
+		Parse.Used_task(task.label)
+	end
+
 	if task and task.dependsOn then
 		run_dependent_tasks(task, selection_list)
 		return

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -86,7 +86,29 @@ local start_job = function(opts)
 
 	local output = {}
 	local job_id
-	job_id = vim.fn.jobstart(command, {
+
+	local open_terminal = options.terminal
+
+	-- Create a new buffer for the terminal
+	local current_buf = vim.api.nvim_get_current_buf()
+	local buf = vim.api.nvim_create_buf(true, false)
+	if open_terminal == true then
+		notify("Starting task..." .. options.label, vim.log.levels.INFO)
+		handle_direction(options.direction)
+	else
+		notify("Starting backgrounded task..." .. options.label, vim.log.levels.INFO)
+	end
+
+	-- show the buffer
+	vim.api.nvim_win_set_buf(0, buf)
+
+	-- Set buffer name after terminal creation
+	vim.schedule(function()
+		name_buffer(buf, options.label)
+	end)
+	job_id = vim.fn.jobstart(options.command, {
+		term = open_terminal,
+		pty = open_terminal,
 		on_stdout = function(_, data)
 			if data then
 				vim.list_extend(output, data)
@@ -128,28 +150,6 @@ local start_job = function(opts)
 				end
 			end
 		end,
-	local open_terminal = options.terminal
-
-	-- Create a new buffer for the terminal
-	local current_buf = vim.api.nvim_get_current_buf()
-	local buf = vim.api.nvim_create_buf(true, false)
-	if open_terminal == true then
-		notify("Starting task..." .. options.label, vim.log.levels.INFO)
-		handle_direction(options.direction)
-	else
-		notify("Starting backgrounded task..." .. options.label, vim.log.levels.INFO)
-	end
-
-	-- show the buffer
-	vim.api.nvim_win_set_buf(0, buf)
-
-	-- Set buffer name after terminal creation
-	vim.schedule(function()
-		name_buffer(buf, options.label)
-	end)
-	job_id = vim.fn.jobstart(options.command, {
-		term = open_terminal,
-		pty = open_terminal,
 		on_exit = function(_, exit_code)
 			local job = background_jobs[job_id]
 

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -195,9 +195,9 @@ local start_job = function(opts)
 						-- Copy terminal buffer content to live output buffer
 						local content = get_buffer_content(job_id)
 						pcall(function()
-							vim.api.nvim_buf_set_option(live_output_buffers[job_id], "modifiable", true)
+							vim.bo[live_output_buffers[job_id]].modifiable = true
 							vim.api.nvim_buf_set_lines(live_output_buffers[job_id], 0, -1, false, content)
-							vim.api.nvim_buf_set_option(live_output_buffers[job_id], "modifiable", false)
+							vim.bo[live_output_buffers[job_id]].modifiable = false
 						end)
 
 						-- Always scroll to bottom for live updates
@@ -219,9 +219,9 @@ local start_job = function(opts)
 						-- Copy terminal buffer content to live output buffer
 						local content = get_buffer_content(job_id)
 						pcall(function()
-							vim.api.nvim_buf_set_option(live_output_buffers[job_id], "modifiable", true)
+							vim.bo[live_output_buffers[job_id]].modifiable = true
 							vim.api.nvim_buf_set_lines(live_output_buffers[job_id], 0, -1, false, content)
-							vim.api.nvim_buf_set_option(live_output_buffers[job_id], "modifiable", false)
+							vim.bo[live_output_buffers[job_id]].modifiable = false
 						end)
 
 						-- Scroll to bottom if cursor was at bottom
@@ -449,10 +449,10 @@ local function preview_job_output(output, bufnr, job_id)
 	end
 
 	-- Set the lines in the preview buffer
-	vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+	vim.bo[bufnr].modifiable = true
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, filtered_output)
-	vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
-	vim.api.nvim_set_option_value("filetype", "sh", { buf = bufnr })
+	vim.bo[bufnr].modifiable = false
+	vim.bo[bufnr].filetype = "sh"
 
 	-- Center the content in the preview window
 	vim.schedule(function()
@@ -627,6 +627,7 @@ local function handle_direction(direction, prompt_bufnr, selection_list, is_laun
 	end
 
 	if direction == "background_job" or direction == "watch_job" then
+		cleaned = Parse.replace(cleaned)
 		-- If task has dependencies, run them first
 		start_job({
 			label = label,

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -359,9 +359,7 @@ local function restart_watched_jobs()
 			vim.fn.jobstop(job_id)
 
 			-- Use timer to ensure job is fully stopped before restarting
-			local job_status = vim.fn.jobwait({ job_id }, -1)[1]
-			local is_running = job_status == -1
-			if not is_running then
+			if not Job.is_running(job_id) then
 				-- Remove from background_jobs to prevent duplicate entries
 				Job.set_background_jobs(job_id, nil)
 
@@ -516,15 +514,6 @@ local function jobs_picker(opts)
 					end
 
 					local job = Job.get_background_job(selected_job.id)
-
-					local is_running = vim.fn.jobwait({ job.id }, 0)[1] == -1
-
-					if is_running then
-						vim.fn.jobstop(job.id)
-						vim.notify(string.format("Killed running job: %s", job.label), vim.log.levels.INFO)
-					else
-						vim.notify(string.format("Removed completed job: %s", job.label), vim.log.levels.INFO)
-					end
 
 					Job.fully_clear_job(job.id)
 

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -540,8 +540,10 @@ local function jobs_picker(opts)
 
 				local job = Job.get_background_job(selected_job.id)
 
+				-- Close the picker first
+				actions.close(prompt_bufnr)
 				Job.fully_clear_job(job)
-				refresh_picker()
+				jobs_picker(opts)
 			end
 			local toggle_watch_binding = function()
 				local selection = state.get_selected_entry()

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -548,7 +548,9 @@ local function jobs_picker(opts)
 			local toggle_watch_binding = function()
 				local selection = state.get_selected_entry()
 				local job = jobs_list[selection.index]
+				actions.close(prompt_bufnr)
 				Job.toggle_watch(job.id)
+				jobs_picker(opts)
 			end
 
 			local open_job = function()

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -595,29 +595,17 @@ local function handle_direction(direction, prompt_bufnr, selection_list, is_laun
 		return
 	end
 
-	if direction == "background_job" or direction == "watch_job" then
-		cleaned = Parse.replace(cleaned)
-		-- If task has dependencies, run them first
+	local process = function(prepared_command)
 		start_job({
 			label = label,
-			command = cleaned,
+			command = prepared_command,
 			silent = false,
 			watch = direction == "watch_job",
-			terminal = false,
+			terminal = direction ~= "background_job",
+			direction = direction,
 		})
-	else
-		local process = function(prepared_command)
-			start_job({
-				label = label,
-				command = prepared_command,
-				silent = false,
-				watch = false,
-				terminal = true,
-				direction = direction,
-			})
-		end
-		Parse.replace_and_run(cleaned, process, opts)
 	end
+	Parse.replace_and_run(cleaned, process, opts)
 end
 
 local function start_launch_direction(direction, prompt_bufnr, _, selection_list, opts)

--- a/lua/vstask/Telescope.lua
+++ b/lua/vstask/Telescope.lua
@@ -535,7 +535,7 @@ local function jobs_picker(opts)
 					Job.toggle_watch(job.id)
 				end
 
-				local open_history = function()
+				local open_job = function()
 					local selection = state.get_selected_entry()
 					actions.close(prompt_bufnr)
 					local job = jobs_list[selection.index]
@@ -567,8 +567,8 @@ local function jobs_picker(opts)
 
 				map("i", Mappings.kill_job, kill_job)
 				map("n", Mappings.kill_job, kill_job)
-				map("i", Mappings.current, open_history)
-				map("n", Mappings.current, open_history)
+				map("i", Mappings.current, open_job)
+				map("n", Mappings.current, open_job)
 				map("i", Mappings.split, open_horizontal)
 				map("n", Mappings.split, open_horizontal)
 				map("i", Mappings.vertical, open_vertical)

--- a/lua/vstask/init.lua
+++ b/lua/vstask/init.lua
@@ -30,6 +30,9 @@ local function config(opts)
 	if opts.json_parser ~= nil then
 		M.Parse.Set_json_parser(opts.json_parser)
 	end
+	if opts.buffer_options ~= nil then
+		M.Parse.Set_buffer_options(opts.buffer_options)
+	end
 end
 
 M.config = function(opts)

--- a/lua/vstask/init.lua
+++ b/lua/vstask/init.lua
@@ -9,9 +9,6 @@ local function config(opts)
 	if opts == nil then
 		return
 	end
-	if opts.terminal ~= nil and opts.terminal == "toggleterm" then
-		M.Telescope.Set_command_handler(require("vstask.ToggleTerm").Process)
-	end
 	if opts.telescope_keys ~= nil then
 		M.Telescope.Set_mappings(opts.telescope_keys)
 	end

--- a/lua/vstask/init.lua
+++ b/lua/vstask/init.lua
@@ -33,6 +33,9 @@ local function config(opts)
 	if opts.buffer_options ~= nil then
 		M.Parse.Set_buffer_options(opts.buffer_options)
 	end
+	if opts.default_tasks ~= nil then
+		M.Parse.Set_default_tasks(opts.default_tasks)
+	end
 end
 
 M.config = function(opts)


### PR DESCRIPTION
- major refactor of job API to use nvim terminal for all jobs
- background jobs are hidden from buffer list
- tasks are now all named using label, including in buffer list
- live previews in jobs picker auto updates
- jobs automatically have color indicating completion even when picker is open on exit
- no more job history, all jobs are in picker, including past and present
- new fn `cleanup_completed_jobs` to remove all jobs that have finished
- new default_tasks config to allow for commands to always be loaded into picker, or optionally load based on filetype