### PR TITLE
Allow for windows section in tasks.json for override of command

### DIFF
--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -394,6 +394,19 @@ local function get_tasks()
 
 		for _, task in pairs(tasks["tasks"]) do
 			task.source = "tasks.json" -- Mark tasks from tasks.json
+			
+			-- Check if running on Windows and if a 'windows' specific configuration exists
+			if vim.fn.has('win32') == 1 and task.windows then
+				-- Iterate over the properties defined in the 'windows' block
+				-- and override the top-level task properties
+				for win_key, win_value in pairs(task.windows) do
+					-- Only override if the key is actually one we'd expect in a task
+					if task[win_key] ~= nil or win_key == 'command' or win_key == 'args' or win_key == 'options' or win_key == 'cwd' then
+						task[win_key] = win_value
+					end
+				end
+			end
+			
 			table.insert(task_list, task)
 		end
 		::continue::


### PR DESCRIPTION
This should allow for a windows block inside the tasks.json file which then will override values. It could be expanded for linux, mac specific commands if needed ( currently not done).

e.g. 
"command" : "linux specific command",
"windows" : {
  "command" : "windows specific command"
}

(see also code snippet in https://code.visualstudio.com/docs/debugtest/tasks#_custom-tasks )


The code was generated with gemini as I'm no lua crack and needed a quick solution today. 

Perhaps it needs some modifications.