### PR TITLE
feat(parse): add support for .code-workspace files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Telescope plugin to load and run tasks in a project that conform to VS Code's [E
 
 - ⚙ Run commands in a terminal as jobs!
   - split or float the terminal
-  - source from ./vscode/tasks.json
+  - source from `./vscode/tasks.json` or `./*.code-workspace` file
   - source from package.json scripts
 - With jobs picker, see all running and completed jobs, including a live output preview
 - 👀 Run any task as a watched job
@@ -19,7 +19,7 @@ Telescope plugin to load and run tasks in a project that conform to VS Code's [E
 - 🐚 run shell commands with .run() or `<C-r>`
 - basic support for option picker for task input (similar to extension.commandvariable.pickStringRemember)
 - dependsOn and dependsOrder support, utilizing the background jobs feature. View with Jobs picker
-- add default tasks in setup for projects without .vscode/tasks.json, or of you want to add your own
+- add default tasks in setup for projects without `.vscode/tasks.json` or `./*.code-workspace`, or if you want to add your own
 
 ## Example
 
@@ -171,6 +171,7 @@ require("vstask").setup({
   cache_json_conf = true, -- don't read the json conf every time a task is ran
   cache_strategy = "last", -- can be "most" or "last" (most used / last used)
   config_dir = ".vscode", -- directory to look for tasks.json and launch.json
+  support_code_workspace = true -- load from a *.code-workspace file, if available
   telescope_keys = { -- change the telescope bindings used to launch tasks
     vertical = '<C-v>',
     split = '<C-p>',

--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -602,13 +602,16 @@ end
 local function get_predefined_variables(command)
 	local predefined_vars = {}
 	local count = 0
-	for defined_var, _ in pairs(Predefined) do
-		local match_pattern = "${" .. defined_var .. "}"
-		for w in string.gmatch(command, match_pattern) do
-			if w ~= nil then
-				for word in string.gmatch(command, "%{(%a+)}") do
-					table.insert(predefined_vars, word)
-					count = count + 1
+
+	if command then
+		for defined_var, _ in pairs(Predefined) do
+			local match_pattern = "${" .. defined_var .. "}"
+			for w in string.gmatch(command, match_pattern) do
+				if w ~= nil then
+					for word in string.gmatch(command, "%{(%a+)}") do
+						table.insert(predefined_vars, word)
+						count = count + 1
+					end
 				end
 			end
 		end

--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -394,19 +394,25 @@ local function get_tasks()
 
 		for _, task in pairs(tasks["tasks"]) do
 			task.source = "tasks.json" -- Mark tasks from tasks.json
-			
+
 			-- Check if running on Windows and if a 'windows' specific configuration exists
-			if vim.fn.has('win32') == 1 and task.windows then
+			if vim.fn.has("win32") == 1 and task.windows then
 				-- Iterate over the properties defined in the 'windows' block
 				-- and override the top-level task properties
 				for win_key, win_value in pairs(task.windows) do
 					-- Only override if the key is actually one we'd expect in a task
-					if task[win_key] ~= nil or win_key == 'command' or win_key == 'args' or win_key == 'options' or win_key == 'cwd' then
+					if
+						task[win_key] ~= nil
+						or win_key == "command"
+						or win_key == "args"
+						or win_key == "options"
+						or win_key == "cwd"
+					then
 						task[win_key] = win_value
 					end
 				end
 			end
-			
+
 			table.insert(task_list, task)
 		end
 		::continue::

--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -494,6 +494,22 @@ local function get_tasks()
 				end
 			end
 
+			-- Escape any problematic chars for the shell
+			if task.args ~= nil then
+				local function shell_escape(arg)
+					if string.find(arg, "[^%w_%-%.%/]") then
+						return string.format("'%s'", string.gsub(arg, "'", "'\\''"))
+					else
+						return arg
+					end
+				end
+
+				local escaped_args = {}
+				for _, arg in pairs(task.args) do
+					table.insert(escaped_args, shell_escape(arg))
+				end
+				task.args = escaped_args
+			end
 			table.insert(task_list, task)
 		end
 	end

--- a/lua/vstask/Parse.lua
+++ b/lua/vstask/Parse.lua
@@ -551,9 +551,11 @@ end
 local function get_input_variables(command)
 	local input_variables = {}
 	local count = 0
-	for w in string.gmatch(command, "${input:([^}]*)}") do
-		table.insert(input_variables, w)
-		count = count + 1
+	if command then
+		for w in string.gmatch(command, "${input:([^}]*)}") do
+			table.insert(input_variables, w)
+			count = count + 1
+		end
 	end
 	return input_variables, count
 end

--- a/lua/vstask/init.lua
+++ b/lua/vstask/init.lua
@@ -24,6 +24,9 @@ local function config(opts)
 	if opts.config_dir ~= nil then
 		M.Parse.Set_config_dir(opts.config_dir)
 	end
+	if opts.support_code_workspace ~= nil then
+		M.Parse.Set_support_code_workspace(opts.support_code_workspace)
+	end
 	if opts.cache_json_conf ~= nil then
 		M.Parse.Set_cache_json_conf(opts.cache_json_conf)
 	end


### PR DESCRIPTION
**Preamble**: I've been writing my own nvim plugin in an effort to add task-like functionality for Unreal Engine plugin development, and as one does... slowly realized that the true final form of the plugin would parse VS Code config files. That's how I wound up finding your plugin, which is fantastic, but it doesn't support [Visual Studio Code's `.code-workspace`](https://code.visualstudio.com/docs/editing/workspaces/workspaces) files that UE's project file generation spits out. 

---

Taking a look yesterday, I was delighted to see how nicely organized you structured this plugin, which made the implementation fairly straightforward. 
What I've done:
- I made a wrapping call, `get_vscode_config()` that takes an enum (inputs / launch / tasks). This will directly return the table contained in the config (or nil, if it doesn't exist), so it somewhat simplifies the getters for inputs / launch / tasks by a small handful of lines.
- I also automatically parse the args for every command (if there are any) and wrap them in quotes if they happen to have characters that might trip up the shell.
- Added a configuration variable (`support_code_workspace`) & updated the README, as well as the error messages.

Hopefully it's not too disruptive, I did my best to keep things aligned with your code style and general approach. Let me know if you have any feedback or changes I should make. 

Thanks!